### PR TITLE
Improve problem listing in /status

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,6 +1,8 @@
 import asyncio
 import os
 import html
+import re
+import datetime
 from io import BytesIO
 
 from dotenv import load_dotenv
@@ -30,13 +32,42 @@ app = FastAPI()
 # Aiogram command handlers
 @dp.message(Command("status"))
 async def cmd_status(msg: types.Message):
-    problems = await zbx.call("problem.get", {"output": ["severity"]})
-    sev_map = {0: "Не классифицировано", 1: "Информация", 2: "Предупреждение", 3: "Средняя", 4: "Высокая", 5: "Критическая"}
+    params = {
+        "output": ["name", "severity", "clock"],
+        "selectHosts": ["name"],
+        "sortfield": "clock",
+        "sortorder": "DESC",
+    }
+    problems = await zbx.call("problem.get", params)
+
+    sev_map = {
+        0: "Не классифицировано",
+        1: "Информация",
+        2: "Предупреждение",
+        3: "Средняя",
+        4: "Высокая",
+        5: "Критическая",
+    }
+
     counts = {name: 0 for name in sev_map.values()}
+    details = []
     for pr in problems:
-        counts[sev_map[int(pr["severity"])]] += 1
+        sev_name = sev_map[int(pr["severity"])]
+        counts[sev_name] += 1
+
+        host = pr.get("hosts", [{}])[0].get("name", "?")
+        clock = int(pr.get("clock", 0))
+        ts = datetime.datetime.fromtimestamp(clock).strftime("%Y-%m-%d %H:%M")
+        details.append(
+            f"{sev_name} — <b>{html.escape(host)}</b>: {html.escape(pr['name'])} ({ts})"
+        )
+
     lines = [f"{k}: <b>{v}</b>" for k, v in counts.items() if v]
+
     text = "✅ Проблем нет" if not lines else "🖥 <b>Сводка проблем</b>\n" + "\n".join(lines)
+    if details:
+        text += "\n\n<b>Текущие проблемы:</b>\n" + "\n".join(details[:15])
+
     await msg.answer(text)
 
 @dp.message(Command("ping"))
@@ -77,7 +108,7 @@ async def cmd_graph(msg: types.Message, command: Command):
 async def cmd_help(msg: types.Message):
     text = (
         "<b>📖 Список команд Phystech Zabbix Bot:</b>\n\n"
-        "/status — сводка открытых проблем\n"
+        "/status — сводка и список открытых проблем\n"
         "/ping <host> — проверить доступность хоста\n"
         "/graph <itemid> [минут] — построить график метрики\n"
         "/help — показать эту справку"
@@ -91,10 +122,29 @@ def health():
 
 @app.post("/zabbix")
 async def zabbix_alert(req: Request):
+    """Receive alerts from Zabbix and forward them to Telegram."""
     payload = await req.json()
-    text = f"📡 <b>{html.escape(payload.get('subject', 'Zabbix alert'))}</b>\n{html.escape(str(payload.get('message', payload)))}"
+
+    # Remove links from the incoming message to avoid leaking internal URLs
+    raw_message = str(payload.get("message", payload))
+
+    # Try to extract problem/event ID from a link like ?eventid=1234
+    id_match = re.search(r"eventid=(\d+)", raw_message)
+
+    # Remove all hyperlinks from the incoming message
+    clean_message = re.sub(r"<a[^>]*>.*?</a>", "", raw_message, flags=re.DOTALL)
+
+    if id_match:
+        clean_message += f"\nНомер проблемы: {id_match.group(1)}"
+
+    text = (
+        f"📡 <b>{html.escape(payload.get('subject', 'Zabbix alert'))}</b>\n"
+        f"{html.escape(clean_message)}"
+    )
+
     for chat_id in ADMIN_CHAT_IDS:
         await bot.send_message(chat_id, text)
+
     return JSONResponse({"ok": True})
 
 # Startup and polling


### PR DESCRIPTION
## Summary
- extend `/status` to list current problems with host names and timestamps
- update help text
- keep hyperlink stripping from webhook payloads
- parse problem ID from webhook message and append to alert text

## Testing
- `python -m py_compile main.py zbx.py`


------
https://chatgpt.com/codex/tasks/task_e_685fe60b29f8832e80c755e1f384331c